### PR TITLE
Fix mermaid graph text color

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 ```mermaid
 graph LR;
 
-  classDef typescriptclass fill:#f96,stroke:#f96;
-  classDef containerclass fill:#fbb,stroke:#fbb;
-  classDef thirdpartyclass fill:#9f6,stroke:#9f6;
+  classDef typescriptclass fill:#f96,stroke:#f96,color:#333;
+  classDef containerclass fill:#fbb,stroke:#fbb,color:#333;
+  classDef thirdpartyclass fill:#9f6,stroke:#9f6,color:#333;
 
   ansible-lint-action --> creator-ee;
   creator-ee --> ansible-lint;


### PR DESCRIPTION
`#333` is the default colour for labels in mermaid graphs and when dark mode on GitHub is activated, mermaid set's the label colour to `#ccc`. This works fine as long as no other styles are changed but as soon as `fill` is specified also the `color` should be set to a specific value so the graph remains readable.

|   | Light Mode  | Dark Mode |
| ----- | ------------- | ------------- |
| before |  ![Screenshot from 2022-03-30 18-00-22](https://user-images.githubusercontent.com/856916/160882382-df2d6eb9-02ab-4b70-ac9a-f4e5b6d677fd.png)  |  ![Screenshot from 2022-03-30 18-00-07](https://user-images.githubusercontent.com/856916/160882317-67a9efed-4a65-422e-8c5c-696973e8c7f6.png)   |
| after | ![Screenshot from 2022-03-30 18-01-07](https://user-images.githubusercontent.com/856916/160882577-2d265772-f9cc-431d-8f36-898bfdff0303.png)  | ![Screenshot from 2022-03-30 18-00-46](https://user-images.githubusercontent.com/856916/160882405-b0efdd80-d49c-4efd-bb26-393af9d6ecd2.png)  |


