### PR TITLE
Temporary use release-drafter fork

### DIFF
--- a/.github/workflows/ack.yml
+++ b/.github/workflows/ack.yml
@@ -18,7 +18,9 @@ jobs:
       # Use of release drafter action for adding semantic labels based on
       # either title, body or source branch name. We ignore potential failure
       # of this step.
-      - uses: release-drafter/release-drafter@v5
+      - uses: paperless-ngx/release-drafter@master
+        # Temporary use fork until https://github.com/release-drafter/release-drafter/pull/1240 fix is released
+        # uses: release-drafter/release-drafter@v5
         with:
           # we only want to use the auto-labeler bits:
           disable-autolabeler: false


### PR DESCRIPTION
This will fix pre-releases to include all changes since the last full release, instead of just the previous any-kind-of-release. To be reverted once this feature ships into release-drafter, as maintainer already agreed about the feature/bug.

Basically it means that making a pre-release does not reset the pending changelog to zero.