### PR TITLE
use actions/checkout@v3

### DIFF
--- a/.github/workflows/ack.yml
+++ b/.github/workflows/ack.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       # Use of release drafter action for adding semantic labels based on
       # either title, body or source branch name. We ignore potential failure

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
           python3 -m pip install --user tox
 
       - name: Check out src from Git
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0  # needed by setuptools-scm
 


### PR DESCRIPTION
This PR:
- replaces `actions/checkout@v2` with `actions/checkout@v3`, due to Node.js 12 actions are deprecated. For more information see https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

Signed-off-by: Thomas Sjögren <konstruktoid@users.noreply.github.com>