### PR TITLE
Add ansible-navigator debugging doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,3 +85,7 @@ graph LR;
  click molecule href "https://github.com/ansible-community/molecule"
  click molecule-podman href "https://github.com/ansible-community/molecule-podman"
 ```
+
+## Devtools projects debug guide
+
+* [Debugging Ansible Navigator with VSCode](https://github.com/shatakshiiii/debuggingNavigator/blob/main/README.md)


### PR DESCRIPTION
This PR:
- Adds a new section in README as **Devtools projects debug guide** listing `ansible-navigator` debugging doc.
- This doc will serve as a basic `ansible-navigator` debug guide for anyone who wants to contribute to the project!