### PR TITLE
release_collection.yml workflow - secrets should not be required

### DIFF
--- a/.github/workflows/release_collection.yml
+++ b/.github/workflows/release_collection.yml
@@ -17,9 +17,9 @@ on:
         type: boolean
     secrets:
       ah_token:
-        required: true
+        required: false
       ansible_galaxy_api_key:
-        required: true
+        required: false
 
 jobs:
   release:
@@ -35,12 +35,14 @@ jobs:
       - name: "Publish the collection on Galaxy"
         if: ${{ inputs.galaxy_publish }}
         run: |
+          [[ "${{ secrets.ansible_galaxy_api_key != '' }}" ]] || { echo "ansible_galaxy_api_key is required to publish on galaxy" ; exit 1; }
           TARBALL=$(ls -1 ./*.tar.gz)
           ansible-galaxy collection publish "${TARBALL}" --api-key "${{ secrets.ansible_galaxy_api_key }}"
 
       - name: "Publish the collection on Automation Hub"
         if: ${{ inputs.ah_publish }} # failed automationhub job not prohibit galaxy job
         run: |
+          [[ "${{ secrets.ah_token != '' }}" ]] || { echo "ah_token is required to publish on automation hub" ; exit 1; }
           TARBALL=$(ls -1 ./*.tar.gz)
           cat << EOF > ansible.cfg
           [galaxy]


### PR DESCRIPTION
While using the reusable workflow `release_collection.yml`, both `ansible_galaxy_api_key` and `ah_token` are required knowing that the user can decide to publish only on one hub.
The pull request set secrets as not required and add some additional steps that the secret was provided when trying to publish